### PR TITLE
[fix] error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,6 @@ module.exports = function(options) {
         gutil.log('gulp-rsync:', 'Completed rsync.');
       }
       cb();
-    });
+    }.bind(this));
   }); 
 };


### PR DESCRIPTION
this.emit('error', ...) fails because `this` is lost in the callback function scope
