### PR TITLE
Resolve crashing due to 'setCursor' on stdout when piped

### DIFF
--- a/log.js
+++ b/log.js
@@ -4,7 +4,7 @@ var gutil = require('gulp-util');
 var util = require('util');
 
 function log() {
-  process.stdout.write(util.format.apply(this, arguments));
+  process.stdout.write(util.format.apply(this, arguments)); 
 }
 
 module.exports = function() {

--- a/log.js
+++ b/log.js
@@ -5,7 +5,6 @@ var util = require('util');
 
 function log() {
   process.stdout.write(util.format.apply(this, arguments));
-  process.stdout.cursorTo(0);
 }
 
 module.exports = function() {


### PR DESCRIPTION
Removing the line 'process.stdout.cursorTo(0);' prevents gulp-rsync from crashing when stdout is being piped to a file or an IDE. All tests past after this change.