### PR TITLE
add option support for rsync --links to make remote symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ Type: `boolean`, Default: `false`
 
 Turns off logging.
 
+###### `links`
+
+Type: `boolean`, Default: `false`
+
+Enables creation of symbolic links on the receiving end.
+
 #### License
 
 > The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ module.exports = function(options) {
         'z': options.compress,
         'exclude': options.exclude,
         'include': options.include,
-        'progress': options.progress
+        'progress': options.progress,
+        'links': options.links
       },
       source: sources.map(function(source) {
         return path.relative(cwd, source.path) || '.';


### PR DESCRIPTION
Thanks for the gulp module!

I added support for a "links" option to allow the remote server to rebuild symlinks, take it if you're interested.