### PR TITLE
Added --chmod, -a, -n, changed Windows backslashes to slashes, updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## gulp-rsync
 
-Use the file transferring and syncing capabilities of rsync within your Gulp task.
+Use the file transferring and syncing capabilities of `rsync` within your Gulp task. `gulp-rsync` calls `rsync` and offers you a subset of options for an easy setup.
 
 ### Prerequisites
 
-rsync needs to be installed on your machine.
+`rsync` needs to be installed on your machine and must be sitting in your PATH.
 
 ### Installation
 
@@ -21,12 +21,74 @@ var rsync = require('gulp-rsync');
 gulp.task('deploy', function() {
   gulp.src('build/**')
     .pipe(rsync({
-      root: 'build',
+      root: 'build/',
       hostname: 'example.com',
-      destination: '/path/to/site'
+      destination: 'path/to/site/'
     }));
 });
 ```
+
+A common parameter set for `rsync` is 
+
+```
+rsync -avz ...
+```
+
+This can be achieved by:
+
+```js
+var gulp = require('gulp');
+var rsync = require('gulp-rsync');
+
+gulp.task('deploy', function() {
+  gulp.src('build/**')
+    .pipe(rsync({
+      root: 'build/',
+      hostname: 'example.com',
+      destination: 'path/to/site/',
+      archive: true,
+      silent: false,
+      compress: true
+    }));
+});
+```
+
+**Note** that `rsync` does not synchronize your `build/`-directory if you give it a trailing `/`. 
+
+
+### rsync OPTIONS
+
+`rsync-gulp` implements the following options of `rsync`. See the [official documentation](https://rsync.samba.org/documentation.html) for more information.
+
+```
+-a, --archive       archive mode; equals -rlptgoD (no -H,-A,-X)
+-c, --checksum      skip based on checksum, not mod-time & size
+-d, --dirs          transfer directories without recursing
+-e, --rsh=COMMAND   specify the remote shell to use
+-n, --dry-run       perform a trial run with no changes made
+-r, --recursive     recurse into directories
+-t, --times         preserve modification times
+-u, --update        skip files that are newer on the receiver
+-v, --verbose       increase verbosity
+-z, --compress      compress file data during the transfer
+--chmod             affect file and/or directory permissions
+--delete            delete extraneous files from destination dirs
+--exclude=PATTERN   exclude files matching PATTERN
+--include=PATTERN   don't exclude files matching PATTERN
+--port=PORT         specify double-colon alternate port number
+--progress          show progress during transfer
+```
+
+
+### Windows users
+
+When you are syncing from Windows to Unix you might encounter permission  errors or issues resulting from these. A reason can be that `rsync` tries to preserve NTFS file attributes in UNIX. This behaviour can be remedied by:
+
+```js
+chmod: "ugo=rwX"
+```
+
+So, if you are running `rsync` on Windows put this option in place.
 
 ### API
 
@@ -45,7 +107,7 @@ The destination path. Use `hostname` when using a remote path.
 Type: `string`, Default: `process.cwd()`
 
 Specifying a root path changes the path names that are transferred to the
-destination. The paths piped into rsync must be within the root path (or the
+destination. The paths piped into `rsync` must be within the root path (or the
 plugin will yell at you).
 
 ```js
@@ -65,10 +127,10 @@ This will create the directory `js` in `/tmp`.
 
 Type: `string`
 
-The hostname of the destination. rsync will connect to this hostname using SSH
+The hostname of the destination. `rsync` will connect to this hostname using SSH
 along with configuration in `~/.ssh/config` or SSH keys stored in a keychain.
 
-When this is omitted, rsync will transfer the content to a local path.
+When this is omitted, `rsync` will transfer the content to a local path.
 
 ###### `username`
 
@@ -78,9 +140,9 @@ Used to specify a user for the remote host.
 
 ###### `shell`
 
-Type: `string`
+Type: `string`, Compares to: `rsync -e`
 
-Typically, rsync is configured to use `ssh` by default, but you may prefer to
+Typically, `rsync` is configured to use `ssh` by default, but you may prefer to
 use `rsh` on a local network.
 
 ###### `port`
@@ -88,20 +150,46 @@ use `rsh` on a local network.
 Type: `integer`
 
 Used to specify an SSH port for the remote host. Note: This will override the
-shell option and force the use of `ssh`.
+shell option and force the use `ssh` in `rsync -e ssh --port=PORT`.
+
+###### `archive`
+
+Type: `boolean`, Default: `false`, Compares to: `rsync -a`
+
+If set to `true`, `rsync` will turn on the archive mode which equals `-rlptgoD`:
+
+```
+-r, --recursive  recurse into directories
+-l, --links      copy symlinks as symlinks
+-p, --perms      preserve permissions
+-t, --times      preserve modification times
+-g, --group      preserve group
+-o, --owner      preserve owner (super-user only)
+-D               same as --devices --specials
+--devices        preserve device files (super-user only)
+--specials       preserve special files
+```
+
+
+###### `dryrun`
+
+Type: `boolean`, Default: `false`, Compares to: `rsync -n`
+
+If set to `true`, `rsync` will do everything it does without actually syncing.
+
 
 ###### `incremental`
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync -c`
 
-If set to `true`, rsync will make incremental updates only. rsync will use the
-checksum of every file to determine whether a file needs to be updated. This
-will add a delay to the transfer, but will minimize the amount of files
+If set to `true`, `rsync` will make incremental updates only. rsync will use the checksum of every file to determine whether a file needs to be updated. This will add a delay to the transfer, but will minimize the amount of files
 transferred each time.
+
+
 
 ###### `progress`
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync --progress`
 
 If set to `true`, the transfer progress for each file will be displayed in the
 console.
@@ -128,9 +216,9 @@ This looks like:
 
 ###### `relative`
 
-Type: `boolean`, Default: `true`
+Type: `boolean`, Default: `true`, Compares to: `rsync -R`
 
-By default, gulp-rsync will transfer all paths relative to the `root` specified.
+By default, `gulp-rsync` will transfer all paths relative to the `root` specified.
 If you want to transfer assets from multiple paths to a single destination, you
 can set `relative` to `false`.
 
@@ -147,19 +235,19 @@ This will transfer all assets (*.js, *.css, and images) into a single directory.
 
 ###### `emptyDirectories`
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync -d`
 
-If set to `true`, rsync will create empty directories.
+If set to `true`, `rsync` will create empty directories.
 
-###### `times`
+###### `times` 
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync -t`
 
 Preserves times of the transferred files.
 
-###### `compress`
+###### `compress` 
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync -z`
 
 Compresses file data during transfer.
 
@@ -167,15 +255,15 @@ Compresses file data during transfer.
 
 Type: `boolean`, Default: `false`
 
-If set to `true`, rsync will transfer all files and subdirectories recursively.
+If set to `true`, `rsync` will transfer all files and subdirectories recursively.
 This is not necessary when using glob(s) with `gulp.src()`. However, it can be
 combined with non-globbed paths to transfer all files:
 
 ```
 gulp.src(['build/js', 'build/css', 'build/images'])
   .pipe(rsync({
-    root: 'build',
-    destination: '/tmp',
+    root: 'build/',
+    destination: 'tmp/',
     recursive: true
   });
 ```
@@ -185,8 +273,8 @@ This is the same as:
 ```
 gulp.src(['build/js/**', 'build/css/**', 'build/images/**'])
   .pipe(rsync({
-    root: 'build',
-    destination: '/tmp'
+    root: 'build/',
+    destination: 'tmp/'
   });
 ```
 
@@ -195,15 +283,21 @@ much shorter.
 
 ###### clean
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync --delete`
 
-This must be used with `recursive` set to `true`. If set to `true`, this
-instructs rsync to delete all files and directories that are not in the source
-paths. **Be careful with this option as it could lead to data loss.**
+This must be used with `archive` or `recursive` set to `true`. If set to `true`, this instructs `rsync` to delete all files and directories that are not in the source paths. **Be careful with this option as it could lead to data loss.**
+
+###### `chmod`
+
+Type: `string`, Compares to: `rsync --chmod=STRING`
+
+Enables files or directories matching the pattern(s) provided to be excluded
+from the transfer. This is probably most useful when `recursive` is set to
+`true` since it is typically better to make these exclusions in `gulp.src()`.
 
 ###### `exclude`
 
-Type: `string|Array<string>`
+Type: `string|Array<string>`, Compares to: `rsync --exclude=PATTERN`
 
 Enables files or directories matching the pattern(s) provided to be excluded
 from the transfer. This is probably most useful when `recursive` is set to
@@ -211,7 +305,7 @@ from the transfer. This is probably most useful when `recursive` is set to
 
 ###### `include`
 
-Type: `string|Array<string>`
+Type: `string|Array<string>`, `rsync --include=PATTERN`
 
 Used with `exclude`. This adds exceptions for the exclusions.
 
@@ -232,21 +326,29 @@ This will transfer only minified CSS and JS files.
 
 ###### `update`
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync -u`
 
 Skip files that are newer on the receiving end.
 
 ###### `silent`
 
-Type: `boolean`, Default: `false`
+Type: `boolean`, Default: `false`, Compares to: `rsync --no-v`
 
 Turns off logging.
+
+
+###### `command`
+
+Type: `boolean`, Default: `false`
+
+This is not a `rsync`-option. If set to `true`, `gulp-rsync` shows you the generated `rsync` command in your shell.
+
 
 #### License
 
 > The MIT License (MIT)
 >
-> Copyright © 2014 Jerry Su, http://jerrysu.me
+> Copyright © 2015 Jerry Su, http://jerrysu.me
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the “Software”), to deal in

--- a/index.js
+++ b/index.js
@@ -75,15 +75,18 @@ module.exports = function(options) {
 
     var config = {
       options: {
+        'a': options.archive,
+        'n': options.dryrun,
         'R': options.relative !== false,
         'c': options.incremental,
         'd': options.emptyDirectories,
         'e': shell,
-        'r': options.recursive,
-        't': options.times,
+        'r': options.recursive && !options.archive,
+        't': options.times && !options.archive,
         'u': options.update,
         'v': !options.silent,
         'z': options.compress,
+        'chmod': options.chmod,
         'exclude': options.exclude,
         'include': options.include,
         'progress': options.progress
@@ -96,10 +99,10 @@ module.exports = function(options) {
     };
 
     if (options.clean) {
-      if (!options.recursive) {
+      if (!options.recursive && !options.archive) {
         this.emit(
           'error',
-          new PluginError('gulp-rsync', 'clean requires recursive option')
+          new PluginError('gulp-rsync', 'clean requires recursive or archive option')
         );
       }
       config.options['delete'] = true;
@@ -110,7 +113,7 @@ module.exports = function(options) {
         data.toString().split('\r').forEach(function(chunk) {
           chunk.split('\n').forEach(function(line, j, lines) {
             log('gulp-rsync:', line, (j < lines.length - 1 ? '\n' : ''));
-          });          
+          });
         });
       };
       config.stdoutHandler = handler;
@@ -123,10 +126,13 @@ module.exports = function(options) {
       if (error) {
         this.emit('error', new PluginError('gulp-rsync', error.stack));
       }
+      if (options.command) {
+        gutil.log(command);
+      }
       if (!options.silent) {
         gutil.log('gulp-rsync:', 'Completed rsync.');
       }
       cb();
     }.bind(this));
-  }); 
+  });
 };

--- a/rsync.js
+++ b/rsync.js
@@ -123,6 +123,7 @@ function escapeShellArg(arg) {
   if (!/(["'`\\ ])/.test(arg)) {
     return arg;
   }
+  arg = arg.replace(/([\\])/g, '/');
   return '"' + arg.replace(/(["'`\\])/g, '\\$1') + '"';
 }
 


### PR DESCRIPTION
1. `--chmod` option (especially for running under Windows).
1. Added very common `-a` option
1. Added dry-run option `-n` for making a careful start and testing when starting to use `gulp-rsync`.
1. Added option `command` to log the `rsync`-command that is generated from `rsync.js`.
1. Dealt with path issue. It seems that `rsync` cannot deal with `\\`. After escaping the `\` from Windows paths in `rsync.js` `rsync` did not generate implied directories. Changed `\` into `/`.
1. Updated `README.md` with additional options from above and more details from `rsync` man pages for higher user convenience and transparency.