### PR TITLE
Fix for Windows paths; and other fixes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,10 +76,12 @@ module.exports = function(options) {
     } else {
       destination = path.relative(cwd, path.resolve(process.cwd(), destination));
     }
+    
+    options.relative = options.relative !== false;
 
     var config = {
       options: {
-        'R': options.relative !== false,
+        'R': options.relative,
         'c': options.incremental,
         'd': options.emptyDirectories,
         'e': shell,
@@ -93,8 +95,22 @@ module.exports = function(options) {
         'progress': options.progress
       },
       source: sources.map(function(source) {
-        var loc = path.relative(cwd, source.path) || '.';
-        if(process.platform === 'win32')  loc = loc.replace(/\\/g, '/');
+        var loc = options.relative
+          ? (path.relative(cwd, source.path) || '.' )
+          : source.path;
+
+        if(process.platform === 'win32') {
+          loc = loc.replace(/\\/g, '/');
+
+          if(!options.relative) {
+            loc = loc.replace(/^([A-Z]):/,
+              function(match, p1, p2){
+                return '/cygdrive/' + p1.toLowerCase();
+              }
+            );
+          }
+        }
+
         return loc;
       }),
       destination: destination,

--- a/index.js
+++ b/index.js
@@ -89,7 +89,9 @@ module.exports = function(options) {
         'progress': options.progress
       },
       source: sources.map(function(source) {
-        return path.relative(cwd, source.path) || '.';
+        var loc = path.relative(cwd, source.path) || '.';
+        if(process.platform === 'win32')  loc = loc.replace(/\\/g, '/');
+        return loc;
       }),
       destination: destination,
       cwd: cwd

--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ module.exports = function(options) {
     sources = sources.filter(function(source) {
       return !source.isNull() ||
         options.emptyDirectories ||
-        (source.path === cwd && options.recursive);
+        ( options.recursive
+          && ( source.path === cwd
+               || source.path.substr(0, cwd.length + 1) === (cwd + path.sep)
+             )
+        );
     });
 
     if (sources.length === 0) {

--- a/rsync.js
+++ b/rsync.js
@@ -80,6 +80,8 @@ rsync.prototype = {
   execute: function(callback) {
     var command = this.command();
 
+    require('gulp-util').log('gulp-rsync:', 'Command: ' + command);
+
     var childProcess;
     if (process.platform === 'win32') {
       childProcess = spawn('cmd.exe', ['/s', '/c', '"' + command + '"'], {


### PR DESCRIPTION
1. Make it work with rsync for Windows. rsync (cwRsync) needs paths with forward slashes. Otherwise, it just uploads a flat structure with filenames like "this\is\a\filename".
2. When option 'recursive', also allow to start from subfolders under the current folder.
3. Do as is asked when option 'relative: false' is set. And make special case for Windows where rsync (cwRsync) requires a 'cygdrive' substitution, e.g. 'D:\Sub\folder' -> '/cygdrive/d/Sub/folder'.
4. Gulp-log the generated rsync command. Helpful to check the effect of the various options!

Changes are tested under Windows, with options
incremental: true,
progress: true,
times: true,
compress: true,
recursive: true,
clean: true
and with and without relative: false.
