### PR TITLE
Adds `chown` option and its docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ Enables files or directories matching the pattern(s) provided to be excluded
 from the transfer. This is probably most useful when `recursive` is set to
 `true` since it is typically better to make these exclusions in `gulp.src()`.
 
+###### `chown`
+
+Type: `string`, Compares to: `rsync --chown=STRING`
+
+Forces all remote files to be owned by the USER:GROUP provided in the string. If GROUP is empty, the trailing colon may be omitted, but if USER is empty, a leading colon must be supplied. If you're running macOS please check your rsync version with `rsync --version`. The default system version, older than 3.1.0, doesn't support this option. You can fix this by installing a recent version from Brew (`brew install homebrew/dupes/rsync`) or MacPorts (`sudo port install rsync`).
+
 ###### `exclude`
 
 Type: `string|Array<string>`, Compares to: `rsync --exclude=PATTERN`

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ module.exports = function(options) {
         'v': !options.silent,
         'z': options.compress,
         'chmod': options.chmod,
+        'chown': options.chown,
         'exclude': options.exclude,
         'include': options.include,
         'progress': options.progress,


### PR DESCRIPTION
Implements the `chown` option currently missing and requested on #41. 

Forces all remote files to be owned by the USER:GROUP provided in the string. If GROUP is empty, the trailing colon may be omitted, but if USER is empty, a leading colon must be supplied. If you're running macOS please check your rsync version with `rsync --version`. The default system version, older than 3.1.0, doesn't support this option. You can fix this by installing a recent version from Brew (`brew install homebrew/dupes/rsync`) or MacPorts (`sudo port install rsync`).

From rsync docs:

```
--chown=USER:GROUP
    This option forces all files to be owned by USER with group GROUP.
    This  is  a  simpler  interface  than  using  --usermap  and  --groupmap directly,
    but  it  is implemented using those options internally, so you cannot mix them.
    If either the USER or GROUP is empty, no mapping for the omitted user/group will
    occur.  If GROUP is empty, the trailing colon may be omitted, but if USER is
    empty, a leading colon must  be supplied.

    If you specify "--chown=foo:bar, this is exactly the same as specifying
    "--usermap=*:foo --groupmap=*:bar", only easier.
```
