### PR TITLE
Remove gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,12 @@
 
 'use strict';
 
-var gutil = require('gulp-util');
+var fancyLog = require('fancy-log');
+var PluginError = require('plugin-error');
 var log = require('./log.js');
 var path = require('path');
 var rsync = require('./rsync.js');
 var through = require('through2');
-
-var PluginError = gutil.PluginError;
 
 module.exports = function(options) {
   if (typeof options !== 'object') {
@@ -125,7 +124,7 @@ module.exports = function(options) {
       config.stdoutHandler = handler;
       config.stderrHandler = handler;
 
-      gutil.log('gulp-rsync:', 'Starting rsync to ' + destination + '...');
+      fancyLog('gulp-rsync:', 'Starting rsync to ' + destination + '...');
     }
 
     rsync(config).execute(function(error, command) {
@@ -133,10 +132,10 @@ module.exports = function(options) {
         this.emit('error', new PluginError('gulp-rsync', error.stack));
       }
       if (options.command) {
-        gutil.log(command);
+        fancyLog(command);
       }
       if (!options.silent) {
-        gutil.log('gulp-rsync:', 'Completed rsync.');
+        fancyLog('gulp-rsync:', 'Completed rsync.');
       }
       cb();
     }.bind(this));

--- a/log.js
+++ b/log.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var fancyLog = require('fancy-log');
 var util = require('util');
 
 function log() {
-  process.stdout.write(util.format.apply(this, arguments)); 
+  process.stdout.write(util.format.apply(this, arguments));
 }
 
 module.exports = function() {
   // HACK: In order to show rsync's transfer progress, override `console` temporarily...
   var orig = console.log;
   console.log = log;
-  var retval = gutil.log.apply(this, arguments);
+  var retval = fancyLog.apply(this, arguments);
   console.log = orig;
   return retval;
 };

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "homepage": "https://github.com/jerrysu/gulp-rsync",
   "dependencies": {
     "better-assert": "^1.0.1",
+    "fancy-log": "^1.3.3",
     "lodash.every": "^2.4.1",
     "lodash.isstring": "^2.4.1",
-    "gulp-util": "^3.0.0",
+    "plugin-error": "^1.0.1",
     "through2": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes `gulp-util` in favour of non-deprecated packages as described [here](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).

Fixes #55.