### PR TITLE
Ref issue #58 - Using remote rsync path on options

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,8 @@ module.exports = function(options) {
         'exclude': options.exclude,
         'include': options.include,
         'progress': options.progress,
-        'links': options.links
+        'links': options.links,
+        'rsync-path': options.remoteRsyncPath
       },
       source: sources.map(function(source) {
         return path.relative(cwd, source.path) || '.';


### PR DESCRIPTION
 it'd be used like this:

```js
rsyncConf = {
        progress: true,
        incremental: true,
        relative: true,
        emptyDirectories: true,
        recursive: true,
        clean: true,
        exclude: [],
        remoteRsyncPath: "/home/user/bin/rsync"
    };
```

It could be helpfull when you're using a share server and have no access to add rsync to /usr/bin folder.