### PR TITLE
brought up to date, removes deprecated warnings and vulnerabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,12 @@
 
 'use strict';
 
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var fancylog = require('fancy-log');
 var log = require('./log.js');
 var path = require('path');
 var rsync = require('./rsync.js');
 var through = require('through2');
-
-var PluginError = gutil.PluginError;
 
 module.exports = function(options) {
   if (typeof options !== 'object') {
@@ -127,7 +126,7 @@ module.exports = function(options) {
       config.stdoutHandler = handler;
       config.stderrHandler = handler;
 
-      gutil.log('gulp-rsync:', 'Starting rsync to ' + destination + '...');
+      fancylog('gulp-rsync:', 'Starting rsync to ' + destination + '...');
     }
 
     rsync(config).execute(function(error, command) {
@@ -135,10 +134,10 @@ module.exports = function(options) {
         this.emit('error', new PluginError('gulp-rsync', error.stack));
       }
       if (options.command) {
-        gutil.log(command);
+        fancylog(command);
       }
       if (!options.silent) {
-        gutil.log('gulp-rsync:', 'Completed rsync.');
+        fancylog('gulp-rsync:', 'Completed rsync.');
       }
       cb();
     }.bind(this));

--- a/log.js
+++ b/log.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var fancylog = require('fancy-log');
 var util = require('util');
 
 function log() {
@@ -11,7 +11,7 @@ module.exports = function() {
   // HACK: In order to show rsync's transfer progress, override `console` temporarily...
   var orig = console.log;
   console.log = log;
-  var retval = gutil.log.apply(this, arguments);
+  var retval = fancylog.apply(this, arguments);
   console.log = orig;
   return retval;
 };

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
   },
   "homepage": "https://github.com/jerrysu/gulp-rsync",
   "dependencies": {
-    "better-assert": "^1.0.1",
-    "lodash.every": "^2.4.1",
-    "lodash.isstring": "^2.4.1",
-    "gulp-util": "^3.0.0",
-    "through2": "^0.6.1"
+    "better-assert": "^1.0.2",
+    "fancy-log": "^1.3.3",
+    "lodash.every": "^4.6.0",
+    "lodash.isstring": "^4.0.1",
+    "plugin-error": "^1.0.1",
+    "through2": "^3.0.1"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
-    "mocha": "^1.21.4"
+    "chai": "^4.2.0",
+    "mocha": "^7.1.2"
   }
 }


### PR DESCRIPTION
Mostly replaces deprecated gulp-utils but also brings some of the dev tools up-to-date to avoid other warnings.